### PR TITLE
Fix code to match documentation's intent.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1380,7 +1380,7 @@ templates used by the :class:`ModelAdmin` views:
 
         class PersonAdmin(admin.ModelAdmin):
             list_display = ('name', 'age')
-            search_fields = ('name',)
+            search_fields = ('age',)
 
             def get_search_results(self, request, queryset, search_term):
                 queryset, use_distinct = super(PersonAdmin, self).get_search_results(request, queryset, search_term)


### PR DESCRIPTION
The text above the code says...

> For example, to enable search by integer field, you could use...

So the search field should be `age` (obviously because `name` is not an integer) which I think is what the documentation wanted to demonstrate.
